### PR TITLE
Add `flatmap` endpoints to MAP Core server component.

### DIFF
--- a/map_core/knowledgebase/__init__.py
+++ b/map_core/knowledgebase/__init__.py
@@ -1,0 +1,58 @@
+#===============================================================================
+#
+# A simple knowledge base...
+#
+#===============================================================================
+
+from contextlib import ContextDecorator
+
+#===============================================================================
+
+import rdflib
+
+import rdflib_sqlalchemy as sqlalchemy
+sqlalchemy.registerplugins()
+
+from rdflib.plugins.sparql.results.jsonlayer import encode as JSON_results_encode
+from rdflib.plugins.sparql.results.jsonresults import JSONResultSerializer
+
+#===============================================================================
+
+from .namespaces import SCICRUNCH_NS
+
+#===============================================================================
+
+class KnowledgeBase(rdflib.Graph, ContextDecorator):
+    def __init__(self, kb_path):
+        SPARC = rdflib.URIRef('SPARC')
+        store = rdflib.plugin.get('SQLAlchemy', rdflib.store.Store)(identifier=SPARC)
+        super().__init__(store, identifier=SPARC)
+        self.namespace_manager = SCICRUNCH_NS
+        database = rdflib.Literal('sqlite:///{}'.format(kb_path))
+        self.open(database)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    def query(self, sparql, **kwds):
+        results = {}
+        try:
+            query_results = super().query(sparql, **kwds)
+            json_results = JSONResultSerializer(query_results)
+            if json_results.result.type == 'ASK':
+                results['head'] = {}
+                results['boolean'] = json_results.result.askAnswer
+            else:                       # SELECT
+                results['head'] = { 'vars': json_results.result.vars }
+                results['results'] = { 'bindings': [
+                    json_results._bindingToJSON(x) for x in json_results.result.bindings
+                ]}
+        except:
+            pass
+        return JSON_results_encode(results)
+
+#===============================================================================

--- a/map_core/knowledgebase/curie_map.yaml
+++ b/map_core/knowledgebase/curie_map.yaml
@@ -1,0 +1,156 @@
+# From https://github.com/tgbugs/pyontutils/blob/master/nifstd/scigraph/curie_map.yaml
+#
+
+# NO EMPTY
+'': 'file:///ERROR/EMPTY/PREFIX/BANNED/'
+
+# rdf and friends
+'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+'rdfs': 'http://www.w3.org/2000/01/rdf-schema#'
+'owl': 'http://www.w3.org/2002/07/owl#'
+'skos': 'http://www.w3.org/2004/02/skos/core#'
+'foaf': 'http://xmlns.com/foaf/0.1/'
+'prov': 'http://www.w3.org/ns/prov#'
+
+'dc': 'http://purl.org/dc/elements/1.1/'
+'dcterms': 'http://purl.org/dc/terms/'
+'dctypes': 'http://purl.org/dc/dcmitype/'  # FIXME there is no agreement on qnames
+
+# base
+'NIFSTD': 'http://uri.neuinfo.org/nif/nifstd/'
+
+# NIFSTD namespaces
+'BIRNLEX': 'http://uri.neuinfo.org/nif/nifstd/birnlex_'
+'NIFEXT': 'http://uri.neuinfo.org/nif/nifstd/nifext_'
+'NIFRID': 'http://uri.neuinfo.org/nif/nifstd/readable/'
+'NLX': 'http://uri.neuinfo.org/nif/nifstd/nlx_'
+'NLXANAT': 'http://uri.neuinfo.org/nif/nifstd/nlx_anat_'
+'NLXBR': 'http://uri.neuinfo.org/nif/nifstd/nlx_br_'
+'NLXCELL': 'http://uri.neuinfo.org/nif/nifstd/nlx_cell_'
+'NLXCHEM': 'http://uri.neuinfo.org/nif/nifstd/nlx_chem_'
+'NLXDYS': 'http://uri.neuinfo.org/nif/nifstd/nlx_dys_'
+'NLXFUNC': 'http://uri.neuinfo.org/nif/nifstd/nlx_func_'
+'NLXINV': 'http://uri.neuinfo.org/nif/nifstd/nlx_inv_'
+'NLXMOL': 'http://uri.neuinfo.org/nif/nifstd/nlx_mol_'
+'NLXNEURNT': 'http://uri.neuinfo.org/nif/nifstd/nlx_neuron_nt_'
+'NLXOEN': 'http://uri.neuinfo.org/nif/nifstd/oen_'
+'NLXORG': 'http://uri.neuinfo.org/nif/nifstd/nlx_organ_'
+'NLXQUAL': 'http://uri.neuinfo.org/nif/nifstd/nlx_qual_'
+'NLXRES': 'http://uri.neuinfo.org/nif/nifstd/nlx_res_'
+'NLXSUB': 'http://uri.neuinfo.org/nif/nifstd/nlx_subcell_'
+'NLXUBO': 'http://uri.neuinfo.org/nif/nifstd/nlx_ubo_'
+'NLXUNCL': 'http://uri.neuinfo.org/nif/nifstd/nlx_uncl_'
+'SAO': 'http://uri.neuinfo.org/nif/nifstd/sao'
+
+# interlex
+'ILX': 'http://uri.interlex.org/base/ilx_'
+'ilx': 'http://uri.interlex.org/'  # NOTE no /base/
+'ilxr': 'http://uri.interlex.org/base/readable/'
+'TEMP': 'http://uri.interlex.org/temp/uris/'
+'ILXREPLACE': 'http://ILXREPLACE.org/'
+
+# interlex user/org namespaces
+'DICOM': 'http://uri.interlex.org/dicom/uris/terms/'
+'PAR': 'http://uri.interlex.org/fakeobo/uris/obo/PAR_'
+'PAXRAT': 'http://uri.interlex.org/paxinos/uris/rat/labels/'
+'PAXMUS': 'http://uri.interlex.org/paxinos/uris/mouse/labels/'
+'NDA.CDE': 'http://uri.interlex.org/NDA/uris/datadictionary/elements/'
+'ilxtr': 'http://uri.interlex.org/tgbugs/uris/readable/'
+
+# alternate ids
+'GBIF': 'http://www.gbif.org/species/'
+'ITISTSN': 'http://www.itis.gov/servlet/SingleRpt/SingleRpt?search_topic=TSN&search_value='
+'MESH': 'https://meshb.nlm.nih.gov/record/ui?ui='
+'RadLex': 'http://www.radlex.org/RID/'  # matches uberon
+'SBO': 'http://www.ebi.ac.uk/sbo/main/SBO:'  # SBO is a fakeobo
+
+# scicrunch registry
+'SCR': 'http://scicrunch.org/resolver/SCR_'
+
+# ontologies
+'obo': 'http://purl.obolibrary.org/obo/'
+'HP': 'http://purl.obolibrary.org/obo/HP_'
+'RO': 'http://purl.obolibrary.org/obo/RO_'
+'OBI': 'http://purl.obolibrary.org/obo/OBI_'
+'oboInOwl': 'http://www.geneontology.org/formats/oboInOwl#'
+'IAO': 'http://purl.obolibrary.org/obo/IAO_'
+'SO': 'http://purl.obolibrary.org/obo/SO_'
+'BFO': 'http://purl.obolibrary.org/obo/BFO_'
+'DOID': 'http://purl.obolibrary.org/obo/DOID_'
+'MONDO': 'http://purl.obolibrary.org/obo/MONDO_'
+'PATO': 'http://purl.obolibrary.org/obo/PATO_'
+'PR': 'http://purl.obolibrary.org/obo/PR_'
+'PW': 'http://purl.obolibrary.org/obo/PW_'
+'CL': 'http://purl.obolibrary.org/obo/CL_'
+'MA': 'http://purl.obolibrary.org/obo/MA_'
+'MP': 'http://purl.obolibrary.org/obo/MP_'
+'CLO': 'http://purl.obolibrary.org/obo/CLO_'
+'GO': 'http://purl.obolibrary.org/obo/GO_'
+'SIO': 'http://semanticscience.org/resource/SIO_'
+'EFO': 'http://www.ebi.ac.uk/efo/EFO_'
+'SWO': 'http://www.ebi.ac.uk/efo/swo/SWO_'
+'SWOL': 'http://www.ebi.ac.uk/swo/license/SWO_'
+'UBERON': 'http://purl.obolibrary.org/obo/UBERON_'
+'ERO': 'http://purl.obolibrary.org/obo/ERO_'
+'NCBIGene': 'http://www.ncbi.nlm.nih.gov/gene/'
+'NCBITaxon': 'http://purl.obolibrary.org/obo/NCBITaxon_'
+'UO': 'http://purl.obolibrary.org/obo/UO_'
+'CHEBI': 'http://purl.obolibrary.org/obo/CHEBI_'
+'chebi': 'http://purl.obolibrary.org/obo/chebi/'
+'FMA': 'http://purl.org/sig/ont/fma/fma'
+'fma': 'http://purl.org/sig/ont/fma/'
+'HBA': 'http://api.brain-map.org:80/api/v2/data/Structure/'  # FIXME hack :/
+'MBA': 'http://api.brain-map.org/api/v2/data/Structure/'
+#'NEMOANN': 'http://purl.bioontology.org/NEMO/ontology/NEMO_annotation_properties.owl'
+#'NEMO': 'http://purl.bioontology.org/NEMO/ontology/NEMO.owl#NEMO_'
+'BFO1': 'http://www.ifomis.org/bfo/1.1#'
+'BFO1SNAP': 'http://www.ifomis.org/bfo/1.1/snap#'
+'BFO1SPAN': 'http://www.ifomis.org/bfo/1.1/span#'
+'CAO': 'http://www.cognitiveatlas.org/ontology/cogat.owl#CAO_'
+'COGAT': 'http://www.cognitiveatlas.org/ontology/cogat.owl#'
+'COGPO': 'http://www.cogpo.org/ontologies/COGPO_'  # doesn't resolve
+'COGPO1': 'http://www.cogpo.org/ontologies/CogPOver1.owl#COGPO_'
+'COGPO10': 'http://www.cogpo.org/ontologies/CogPOver2010.owl#COGPO_'
+'TRANS': 'http://purl.obolibrary.org/obo/TRANS_'
+'SYMP': 'http://purl.obolibrary.org/obo/SYMP_'
+
+# NIF Import closure
+'BIRNANN': 'http://ontology.neuinfo.org/NIF/Backend/BIRNLex_annotation_properties.owl#'
+'BIRNOBI': 'http://ontology.neuinfo.org/NIF/Backend/BIRNLex-OBI-proxy.owl#'
+'BIRNOBO': 'http://ontology.neuinfo.org/NIF/Backend/BIRNLex-OBO-UBO.owl#'
+#'NIFBE': 'http://ontology.neuinfo.org/NIF/Backend/nif_backend.owl#'
+'NIFQUAL': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Quality.owl#'
+'OBOANN': 'http://ontology.neuinfo.org/NIF/Backend/OBO_annotation_properties.owl#'
+'NIFANN': 'http://ontology.neuinfo.org/NIF/NIF-Annotation-Standard.owl#'
+'NIFCELL': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Cell.owl#'
+'NIFCHEM': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Chemical.owl#'
+'NIFGA': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-GrossAnatomy.owl#'
+'NIFMOL': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Molecule.owl#'
+'NIFORG': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Organism.owl#'
+'NIFSUB': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Subcellular.owl#'
+'NIFUNCL': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Unclassified.owl#'
+'SAOCORE': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/SAO-CORE_properties.owl#'
+'NIFGG': 'http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Government-Granting-Agency.owl#'
+'NIFINV': 'http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Investigation.owl#'
+'NIFRES': 'http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Resource.owl#'
+'NIFSCID': 'http://ontology.neuinfo.org/NIF/DigitalEntities/NIF-Scientific-Discipline.owl#'
+'NIFDYS': 'http://ontology.neuinfo.org/NIF/Dysfunction/NIF-Dysfunction.owl#'
+'NIFFUN': 'http://ontology.neuinfo.org/NIF/Function/NIF-Function.owl#'
+
+# Inferred or Slim
+'NIFMOLINF': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Molecule-Role-Inferred.owl#'
+'NIFNCBISLIM': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-NCBITaxonomy-Slim.owl#'
+
+# Bridge
+#'QUALBB': 'http://ontology.neuinfo.org/NIF/Backend/quality_bfo_bridge.owl#'
+#'NIFERO': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Eagle-I-Bridge.owl#'
+#'NIFGOCC': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-GO-CC-Bridge.owl#'
+'NIFMOLROLE': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Molecule-Role-Bridge#'  #AAAAAAA
+'NIFNCBI': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-NCBITax-Bridge.owl#'
+'NIFNEURMC': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF_Neuron_MolecularConstituent_Bridge.owl#'
+'NIFNEURBR': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Neuron-BrainRegion-Bridge.owl#'
+'NIFNEURBR2': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Neuron-Brain-Bridge.owl#'  #AAAAAAAA
+'NIFNEURCIR': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Neuron-Circuit-Role-Bridge.owl#'
+'NIFNEURMOR': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Neuron-Morphology-Bridge.owl#'
+'NIFNEURNT': 'http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Neuron-NT-Bridge.owl#'
+

--- a/map_core/knowledgebase/namespaces.py
+++ b/map_core/knowledgebase/namespaces.py
@@ -1,0 +1,43 @@
+#===============================================================================
+#
+#  Flatmap viewer and annotation tools
+#
+#  Copyright (c) 2019  David Brooks
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#===============================================================================
+
+import os
+
+#===============================================================================
+
+from rdflib import Graph
+from rdflib.namespace import Namespace, NamespaceManager
+
+import yaml
+
+#===============================================================================
+
+with open(os.path.join(os.path.split(__file__)[0], 'curie_map.yaml')) as f:
+    namespaces = yaml.load(f, Loader=yaml.Loader)
+
+SCICRUNCH_NS = NamespaceManager(Graph())
+module_dict = globals()
+
+for prefix, url in namespaces.items():
+    ns = Namespace(url)
+    SCICRUNCH_NS.bind(prefix, ns, override=True)
+    module_dict[prefix] = ns
+
+#===============================================================================

--- a/map_core/views.py
+++ b/map_core/views.py
@@ -86,9 +86,12 @@ def style(map):
 def map_annotations(map):
     mbtiles = os.path.join(flatmaps_root, map, 'index.mbtiles')
     reader = MBTilesReader(mbtiles)
-    rows = reader._query("SELECT value FROM metadata WHERE name='annotations';")
-    annotations = [row[0] for row in rows]
-    return send_file(io.BytesIO(annotations[0].encode('utf-8')), mimetype='application/json')
+    rows = reader._query("SELECT value FROM metadata WHERE name='annotations';").fetchone()
+    if rows is None:
+        annotations = {}
+    else:
+        annotations = json.loads([row[0] for row in rows][0])
+    return jsonify(annotations)
 
 @map_core_blueprint.route('flatmap/<string:map>/images/<string:image>')
 def map_background(map, image):

--- a/map_core/views.py
+++ b/map_core/views.py
@@ -90,7 +90,7 @@ def map_annotations(map):
     if rows is None:
         annotations = {}
     else:
-        annotations = json.loads([row[0] for row in rows][0])
+        annotations = json.loads(row[0])
     return jsonify(annotations)
 
 @map_core_blueprint.route('flatmap/<string:map>/images/<string:image>')

--- a/map_core/views.py
+++ b/map_core/views.py
@@ -5,7 +5,8 @@
 #################
 
 from app import app
-from flask import render_template, Blueprint, request, make_response, url_for, jsonify, send_file, send_from_directory, redirect
+from flask import render_template, Blueprint, request, make_response, url_for
+from flask import jsonify, send_file, send_from_directory, redirect, abort
 import io
 import json
 from landez.sources import MBTilesReader, ExtractionError
@@ -13,6 +14,8 @@ from logger import logger
 import os.path
 import pathlib
 import requests
+
+from .knowledgebase import KnowledgeBase
 
 ################
 #### config ####
@@ -117,3 +120,12 @@ def image_tiles(map, layer, z, y, x):
     except ExtractionError:
         pass
     return ('', 204)
+
+@map_core_blueprint.route('query', methods=['POST'])
+def kb_query():
+    query = request.get_json()
+    try:
+        with KnowledgeBase(os.path.join(flatmaps_root, 'KnowledgeBase.sqlite')) as graph:
+            return jsonify(graph.query(query.get('sparql')))
+    except RuntimeError:
+        abort(404, 'Cannot open knowledge base')

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,9 @@ protobuf==3.2.0
 psutil==5.5.0
 python-dateutil==2.8.0
 pytz==2018.9
+PyYAML==5.1.1
+rdflib==4.2.2
+rdflib-sqlalchemy==0.3.8
 requests==2.21.0
 s3transfer==0.2.0
 singledispatch==3.4.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ idna==2.8
 itsdangerous==1.1.0
 Jinja2==2.10
 jmespath==0.9.3
+landez==2.5.0
 logger==1.4
 MarkupSafe==1.1.0
 marshmallow==2.18.0


### PR DESCRIPTION
Here is the updated Python server code. The only significant change is that flatmap endpoints are now all under `flatmap/`. This requires a corresponding change to the flatmap viewer -- I'll be making a new release of that which includes this later today.